### PR TITLE
Create RVM Gemset automatically if it does not exist

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use ruby-1.9.2@tomatoist
+rvm use ruby-1.9.2@tomatoist --create


### PR DESCRIPTION
Changed into the tomatoist directory to work on it and I already have rvm 1.9.2-p290 but no gemset.  So --create will auto create it
